### PR TITLE
Change the discovery url to point to production env

### DIFF
--- a/WopiValidatorExecutor/ExecutorConfig.ini
+++ b/WopiValidatorExecutor/ExecutorConfig.ini
@@ -3,4 +3,4 @@
 TestCategory = All
 
 # The latest Discovery Service Url for Test/Production environment can be retrieved from  https://wopi.readthedocs.io/en/latest/build_test_ship/environments.html#discovery-urls
-WopiDiscoveryServiceUrl = https://onenote.officeapps-df.live.com/hosting/discovery
+WopiDiscoveryServiceUrl = https://onenote.officeapps.live.com/hosting/discovery


### PR DESCRIPTION
Change the default discovery url to point to the production environment.
